### PR TITLE
Use compiled packages when searching for a place a given document belongs to

### DIFF
--- a/client_vscode/package.json
+++ b/client_vscode/package.json
@@ -69,7 +69,7 @@
     "@types/which": "^2.0.1",
     "ts-loader": "^9.5.1",
     "typescript": "^4.8.4",
-    "webpack": "^5.91.0",
+    "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {

--- a/lsp/language_server.pony
+++ b/lsp/language_server.pony
@@ -98,7 +98,7 @@ actor LanguageServer is Notifier
           )
         end
       | "textDocument/documentSymbol" =>
-        let document_uri = 
+        let document_uri =
           try
             _get_document_uri(r.params)?
           else

--- a/lsp/symbols.pony
+++ b/lsp/symbols.pony
@@ -154,11 +154,11 @@ primitive DocumentSymbols
     symbols
 
   fun tag find_members(entity: AST, symbol: DocumentSymbol ref, channel: Channel) =>
-    let members = 
+    let members =
       try
         entity(4)?
       else
-        channel.log("No members node at child idx 2 for node " + TokenIds.string(entity.id()))
+        channel.log("No members node at child idx 4 for node " + TokenIds.string(entity.id()))
         return
       end
     if members.id() != TokenIds.tk_members() then
@@ -192,7 +192,6 @@ primitive DocumentSymbols
             )
             let member_symbol = DocumentSymbol(name, kind, full_range, selection_range)
             symbol.push_child(member_symbol)
-            // TODO: recurse even deeper into local variables etc?
           end
         end
     end

--- a/lsp/workspace/data.pony
+++ b/lsp/workspace/data.pony
@@ -13,7 +13,7 @@ class val WorkspaceData
   let dependencies: Array[String] val
   // absolute paths (derived from folder and dependencies)
   let dependency_paths: Array[String] val
-  // absolute paths
+  // absolute paths of packages listed in all corral.json files (including dependencies)
   let package_paths: Set[String] val
   let _min_package_paths_len: USize
   // TODO: further structure a workspace into different packages, separately
@@ -74,5 +74,19 @@ class val WorkspaceData
       doc_path = Path.dir(doc_path)
     end
     None
+
+  fun workspace_path(path: String): FilePath ? =>
+    // check if path is within the workspace folder
+    let found_idx =
+      try
+        path.find(this.folder.path)?
+      else
+        -1
+      end
+    if found_idx == 0 then
+      this.folder.join(path.substring(this.folder.path.size().isize() + 1))?
+    else
+      error
+    end
 
 

--- a/lsp/workspace/state.pony
+++ b/lsp/workspace/state.pony
@@ -46,10 +46,14 @@ class PackageState
     end
 
   fun ref insert_new(document_path: String): (DocumentState, Bool) =>
+    """
+    Insert a new module by the given `document_path` into this package
+    """
     var has_module = false
     let doc_state = DocumentState.create(document_path, this._channel)
 
     try
+      // populate the document from the last compilation result if available
       let pkg = this.package as Package
       let module = pkg.find_module(document_path) as Module
       doc_state.update(module, this.compiler_run_id)
@@ -64,10 +68,14 @@ class PackageState
     )
 
   fun ref update(result: Package val, run_id: USize) =>
+    """
+    Update the current package state with the result of the compilation run identified by `run_id`.
+    """
     this.compiler_run_id = run_id
     this.package = result
     this._channel.log("Updating package " + result.path)
     this._channel.log(this.debug())
+    // for each open document, update the document state if we have a module for it
     for (doc_path, doc_state) in this.documents.pairs() do
       // TODO: ensure both module and package-state paths are normalized
       match result.find_module(doc_path)

--- a/lsp/workspace/state.pony
+++ b/lsp/workspace/state.pony
@@ -45,6 +45,9 @@ class PackageState
       this.documents(document_path)?
     end
 
+  fun has_document(document_path: String): Bool =>
+    this.documents.contains(document_path)
+
   fun ref insert_new(document_path: String): (DocumentState, Bool) =>
     """
     Insert a new module by the given `document_path` into this package


### PR DESCRIPTION
Previously the WorkspaceManager was only looking into explicitly provided dependencies in corral.json, which was wrong in the first place.