### PR TITLE
Support folders with only a main.pony

### DIFF
--- a/lsp/test/_workspace_tests.pony
+++ b/lsp/test/_workspace_tests.pony
@@ -23,8 +23,15 @@ class \nodoc\ iso _RouterFindTest is UnitTest
       })
     let scanner = WorkspaceScanner.create(channel)
     let workspaces = scanner.scan(file_auth, this_dir_path)
-    h.assert_eq[USize](1, workspaces.size())
-    let workspace = workspaces(0)?
+    h.assert_eq[USize](2, workspaces.size())
+    // main.pony workspace has been found first
+    var workspace = workspaces(0)?
+    h.assert_eq[String](folder.path, workspace.folder.path)
+
+    // corral workspace
+    workspace = workspaces(1)?
+    h.assert_eq[String](folder.join("workspace")?.path, workspace.folder.path)
+    
     let router = WorkspaceRouter.create()
     let compiler = PonyCompiler("") // dummy, not actually in use
     


### PR DESCRIPTION
but only if they are not already part of a corral.json folder. In that case, the corral.json data describes the sub-folders fully.