### PR TITLE
Add LSP hover support for Pony language constructs

### DIFF
--- a/lsp/test/_hover_tests.pony
+++ b/lsp/test/_hover_tests.pony
@@ -1,0 +1,80 @@
+use "pony_test"
+use "../workspace"
+
+primitive _HoverTests is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_HoverFormatEntityTest)
+    test(_HoverFormatEntityWithTypeParamsTest)
+    test(_HoverFormatEntityWithDocstringTest)
+    test(_HoverFormatMethodTest)
+    test(_HoverFormatMethodWithReturnTypeTest)
+    test(_HoverFormatMethodWithDocstringTest)
+    test(_HoverFormatFieldTest)
+    test(_HoverFormatFieldWithTypeTest)
+
+class \nodoc\ iso _HoverFormatEntityTest is UnitTest
+  fun name(): String => "hover/format_entity"
+
+  fun apply(h: TestHelper) =>
+    let info = EntityInfo("class", "MyClass")
+    let result = HoverFormatter.format_entity(info)
+    h.assert_eq[String]("```pony\nclass MyClass\n```", result)
+
+class \nodoc\ iso _HoverFormatEntityWithTypeParamsTest is UnitTest
+  fun name(): String => "hover/format_entity_with_type_params"
+
+  fun apply(h: TestHelper) =>
+    let info = EntityInfo("class", "MyClass", "[T: Any val]")
+    let result = HoverFormatter.format_entity(info)
+    h.assert_eq[String]("```pony\nclass MyClass[T: Any val]\n```", result)
+
+class \nodoc\ iso _HoverFormatEntityWithDocstringTest is UnitTest
+  fun name(): String => "hover/format_entity_with_docstring"
+
+  fun apply(h: TestHelper) =>
+    let info = EntityInfo("actor", "MyActor", "", "A sample actor.")
+    let result = HoverFormatter.format_entity(info)
+    h.assert_eq[String]("```pony\nactor MyActor\n```\n\nA sample actor.", result)
+
+class \nodoc\ iso _HoverFormatMethodTest is UnitTest
+  fun name(): String => "hover/format_method"
+
+  fun apply(h: TestHelper) =>
+    let info = MethodInfo("fun", "my_method")
+    let result = HoverFormatter.format_method(info)
+    h.assert_eq[String]("```pony\nfun my_method()\n```", result)
+
+class \nodoc\ iso _HoverFormatMethodWithReturnTypeTest is UnitTest
+  fun name(): String => "hover/format_method_with_return_type"
+
+  fun apply(h: TestHelper) =>
+    let info = MethodInfo("fun", "get_value", "(x: U32)", ": String")
+    let result = HoverFormatter.format_method(info)
+    h.assert_eq[String]("```pony\nfun get_value(x: U32): String\n```", result)
+
+class \nodoc\ iso _HoverFormatMethodWithDocstringTest is UnitTest
+  fun name(): String => "hover/format_method_with_docstring"
+
+  fun apply(h: TestHelper) =>
+    let info = MethodInfo("be", "process", "(data: Array[U8] val)", "", "Process data asynchronously.")
+    let result = HoverFormatter.format_method(info)
+    h.assert_eq[String]("```pony\nbe process(data: Array[U8] val)\n```\n\nProcess data asynchronously.", result)
+
+class \nodoc\ iso _HoverFormatFieldTest is UnitTest
+  fun name(): String => "hover/format_field"
+
+  fun apply(h: TestHelper) =>
+    let info = FieldInfo("let", "name")
+    let result = HoverFormatter.format_field(info)
+    h.assert_eq[String]("```pony\nlet name\n```", result)
+
+class \nodoc\ iso _HoverFormatFieldWithTypeTest is UnitTest
+  fun name(): String => "hover/format_field_with_type"
+
+  fun apply(h: TestHelper) =>
+    let info = FieldInfo("var", "count", ": U32")
+    let result = HoverFormatter.format_field(info)
+    h.assert_eq[String]("```pony\nvar count: U32\n```", result)

--- a/lsp/test/main.pony
+++ b/lsp/test/main.pony
@@ -14,6 +14,7 @@ actor Main is TestList
   fun tag tests(test: PonyTest) =>
     test(_InitializeTest)
     _WorkspaceTests.make().tests(test)
+    _HoverTests.make().tests(test)
 
 primitive _LspMsg
   fun tag apply(msg: String val): Array[U8] iso^ =>

--- a/lsp/test/workspace/hover_fixture.pony
+++ b/lsp/test/workspace/hover_fixture.pony
@@ -1,0 +1,191 @@
+"""
+Test fixtures for LSP hover functionality.
+
+This file provides test cases for manual testing of hover information.
+It contains various Pony entities (classes, actors, traits, methods, fields)
+with docstrings and type annotations to validate hover behavior.
+
+To test hover functionality:
+1. Open the lsp/test/workspace directory as a project in your editor
+2. Open this file with the Pony language server configured
+3. Hover your cursor over various code elements to see hover information
+
+Expected hover behavior:
+- Display the declaration signature in a code block
+- Include docstrings where present
+- Show type information for fields and variables
+"""
+
+class HoverTestClass
+  """
+  A sample class for testing hover.
+  """
+  let field_name: String
+  var mutable_field: U32
+  embed embedded_field: Array[String] = Array[String]
+
+  new create(name: String) =>
+    field_name = name
+    mutable_field = 0
+
+  fun simple_method(): String =>
+    """Returns the field name."""
+    field_name
+
+  fun method_with_params(x: U32, y: String): Bool =>
+    """A method with parameters."""
+    x > 0
+
+  fun ref update_field(count: USize) =>
+    """Update the mutable field."""
+    mutable_field = count.u32()
+
+actor HoverTestActor
+  """
+  A sample actor for testing hover.
+  """
+  let _name: String
+
+  new create(name': String) =>
+    _name = name'
+
+  be do_something(value: U64) =>
+    None
+
+trait HoverTestTrait
+  """
+  A sample trait for testing hover.
+  """
+  fun trait_method(): String
+
+interface HoverTestInterface
+  """
+  A sample interface for testing hover.
+  """
+  fun interface_method(): None val
+
+primitive HoverTestPrimitive
+  """
+  A sample primitive for testing hover.
+  """
+  fun apply(): String => "test"
+
+type HoverTestAlias is (String | U32 | None)
+
+class TypeInferenceDemo
+  """
+  Demonstrates that type inference works in hover!
+  Hover shows inferred types on variable declarations even without explicit annotations.
+  """
+
+  fun demo_type_inference(): String =>
+    """
+    Hover shows inferred types on variable DECLARATIONS!
+    Try hovering over the variable names on their declaration lines.
+
+    ACTUAL: Hover shows 'let inferred_bool: Bool' even without explicit type
+    This works because the type-checked AST contains inferred type info.
+    """
+    let inferred_string = "test"       // Hover shows: let inferred_string: String val
+    let inferred_bool = true           // Hover shows: let inferred_bool: Bool
+    let inferred_array = Array[U32]    // Hover shows: let inferred_array: Array[U32] ref
+
+    inferred_string + inferred_bool.string() + inferred_array.size().string()
+
+// ========== Examples of Current Limitations ==========
+
+class LimitationExamples
+  """
+  This class demonstrates hover limitations - cases where hover doesn't
+  currently provide information but ideally should.
+  """
+
+  // Limitation 1: Function calls don't show signature
+  fun demo_function_calls(): String =>
+    """
+    Try hovering over the method names in the function calls below.
+    EXPECTED: Should show method signature and docstring
+    ACTUAL: No hover information displayed
+    """
+    let result1 = this.helper_method("test")
+    let result2 = this.method_with_multiple_params(42, "hello", true)
+    result1 + result2
+
+  fun helper_method(input: String): String =>
+    """A helper method that processes input."""
+    input.upper()
+
+  fun method_with_multiple_params(x: U32, y: String, flag: Bool): String =>
+    """Method with multiple parameters for testing."""
+    y
+
+  // Limitation 2: Variable usage doesn't show type
+  fun demo_variable_usage() =>
+    """
+    Try hovering over the variable names when they're USED (not declared).
+    EXPECTED: Should show variable type
+    ACTUAL: No hover information (only works on the declaration line)
+    """
+    let count: U32 = 100
+    let name: String = "example"
+
+    // Hover over 'count' or 'name' below - no info shown
+    let doubled = count * 2
+    let upper_name = name.upper()
+    let sum = count + doubled
+
+  // Limitation 3: Complex type expressions
+  fun demo_complex_types(): String =>
+    """
+    Try hovering over these complex type expressions.
+    EXPECTED: Should show formatted type (e.g., '(String | U32 | None)')
+    ACTUAL: May not format complex types correctly
+    """
+    let union_type: (String | U32 | None) = "test"
+    let tuple_type: (String, U32, Bool) = ("test", U32(42), true)
+    union_type.string() + tuple_type._1.string()
+
+  // Limitation 4: Primitive type documentation
+  fun demo_primitive_types(): USize =>
+    """
+    Try hovering over primitive numeric types vs classes.
+    Classes (String, Array): Show full documentation with docstrings
+    Primitives (U32, I64, etc.): Show minimal info, just 'primitive U32'
+
+    This is because primitives in the stdlib may lack docstrings or they
+    aren't being extracted properly from the builtin package.
+    """
+    let text: String = ""           // Hover shows full String documentation
+    let numbers: Array[U32] = []    // Hover shows full Array documentation
+    let value: U32 = 0              // Hover shows just: primitive U32
+    text.size() + numbers.size() + value.usize()
+
+  // Limitation 5: Receiver capabilities not shown in signatures
+  fun box boxed_method(): String =>
+    """
+    A boxed method - receiver capability is 'box'.
+
+    EXPECTED: Hover should show 'fun box boxed_method(): String'
+    ACTUAL: Hover shows 'fun boxed_method(): String' (missing 'box')
+
+    The receiver capability indicates how 'this' can be accessed in the method.
+    """
+    "box"
+
+  fun val valued_method(): String =>
+    """
+    A val method - receiver capability is 'val'.
+
+    EXPECTED: Should show 'fun val valued_method(): String'
+    ACTUAL: Shows 'fun valued_method(): String' (missing 'val')
+    """
+    "val"
+
+  fun ref mutable_method() =>
+    """
+    A ref method - receiver capability is 'ref'.
+
+    EXPECTED: Should show 'fun ref mutable_method()'
+    ACTUAL: Shows 'fun mutable_method()' (missing 'ref')
+    """
+    None

--- a/lsp/workspace/hover.pony
+++ b/lsp/workspace/hover.pony
@@ -1,0 +1,583 @@
+"""
+# LSP Hover Support
+
+This module implements the Language Server Protocol (LSP) `textDocument/hover` capability
+for the Pony language server. Hover provides contextual information when users hover their
+cursor over code elements in the editor.
+
+## LSP Hover Specification
+
+The hover capability is defined in the LSP specification:
+https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover
+
+The hover request returns information about the symbol at a given text document position,
+typically displayed in a tooltip when hovering over code in the editor.
+
+## Implementation Overview
+
+This implementation provides hover information for:
+
+### Supported Language Constructs
+- **Entities**: class, actor, trait, interface, primitive, type, struct
+- **Methods**: fun, be (behavior), new (constructor)
+- **Fields**: let, var, embed
+- **Local Variables**: let, var declarations
+- **References**: Follows identifiers and type references to their definitions
+
+### Hover Information Includes
+- Declaration signatures with keywords and parameters
+- Type annotations for fields and return types
+- Type parameters with constraints
+- Docstrings extracted from the AST
+
+## Architecture
+
+The module is organized into three layers:
+
+### 1. Value Objects (Pure Data)
+- `EntityInfo`: Information about entity declarations
+- `MethodInfo`: Information about method declarations
+- `FieldInfo`: Information about field declarations
+
+### 2. Pure Formatting Functions (Testable)
+- `format_entity()`: Format entity hover text
+- `format_method()`: Format method hover text
+- `format_field()`: Format field hover text
+
+### 3. AST Extraction (Impure)
+- `create_hover()`: Main entry point, dispatches based on AST node type
+- `extract_*_info()`: Extract information from AST nodes
+- `_format_*()`: Format specific node types
+- Helper functions for extracting types, parameters, and docstrings
+
+## Output Format
+
+Hover text is formatted as Markdown with Pony syntax highlighting:
+
+```
+```pony
+class MyClass[T: Any val]
+```
+
+This is a sample class that demonstrates hover functionality.
+```
+
+## Usage
+
+```pony
+let hover_text = HoverFormatter.create_hover(ast_node, channel)
+match hover_text
+| let text: String => // Display in hover tooltip
+| None => // No hover info available
+end
+```
+
+## Limitations
+
+Current implementation does not support:
+- **Function calls**: Hovering over a function call (e.g., `foo()` in `let x = foo()`) doesn't show the function's signature
+- **Variable usage**: Hovering over a variable being used (e.g., `x` in `let y = x + 1`) doesn't show the variable's type
+- **Complex type expressions**: Unions, intersections, tuples not fully formatted
+- **Primitive type documentation**: Numeric primitives (U32, I64, etc.) show minimal info (just `primitive U32`) without docstrings, while classes like String and Array show full documentation
+- **Receiver capabilities**: Method signatures don't include the receiver capability (shows `fun method()` instead of `fun box method()`, `fun ref method()`, etc.)
+"""
+use ".."
+use "ast"
+
+class val EntityInfo
+  """
+  Information about an entity declaration (class, actor, trait, etc.)
+  """
+  let keyword: String
+  let name: String
+  let type_params: String
+  let docstring: String
+
+  new val create(keyword': String, name': String, type_params': String = "", docstring': String = "") =>
+    keyword = keyword'
+    name = name'
+    type_params = type_params'
+    docstring = docstring'
+
+class val MethodInfo
+  """
+  Information about a method declaration (fun, be, new)
+  """
+  let keyword: String
+  let name: String
+  let params: String
+  let return_type: String
+  let docstring: String
+
+  new val create(keyword': String, name': String, params': String = "()", return_type': String = "", docstring': String = "") =>
+    keyword = keyword'
+    name = name'
+    params = params'
+    return_type = return_type'
+    docstring = docstring'
+
+class val FieldInfo
+  """
+  Information about a field declaration (let, var, embed)
+  """
+  let keyword: String
+  let name: String
+  let field_type: String
+
+  new val create(keyword': String, name': String, field_type': String = "") =>
+    keyword = keyword'
+    name = name'
+    field_type = field_type'
+
+primitive HoverFormatter
+  """
+  Extracts hover information from AST nodes and formats as markdown.
+  """
+
+  // ========== Pure Formatting Functions (Testable) ==========
+
+  fun format_entity(info: EntityInfo): String =>
+    """
+    Format entity declaration as markdown hover text.
+    """
+    let declaration = info.keyword + " " + info.name + info.type_params
+    let code_block = _wrap_code_block(consume declaration)
+    if info.docstring.size() > 0 then
+      code_block + "\n\n" + info.docstring
+    else
+      code_block
+    end
+
+  fun format_method(info: MethodInfo): String =>
+    """
+    Format method declaration as markdown hover text.
+    """
+    let signature = info.keyword + " " + info.name + info.params + info.return_type
+    let code_block = _wrap_code_block(consume signature)
+    if info.docstring.size() > 0 then
+      code_block + "\n\n" + info.docstring
+    else
+      code_block
+    end
+
+  fun format_field(info: FieldInfo): String =>
+    """
+    Format field declaration as markdown hover text.
+    """
+    let declaration = info.keyword + " " + info.name + info.field_type
+    _wrap_code_block(consume declaration)
+
+  // ========== AST Extraction and Dispatch ==========
+
+  fun tag create_hover(ast: AST box, channel: Channel): (String | None) =>
+    """
+    Main entry point. Returns markdown string or None if no hover info available.
+    Dispatches to specialized formatters based on AST node type.
+    """
+    match ast.id()
+    // Entity types
+    | TokenIds.tk_class() => _format_entity(ast, "class", channel)
+    | TokenIds.tk_actor() => _format_entity(ast, "actor", channel)
+    | TokenIds.tk_trait() => _format_entity(ast, "trait", channel)
+    | TokenIds.tk_interface() => _format_entity(ast, "interface", channel)
+    | TokenIds.tk_primitive() => _format_entity(ast, "primitive", channel)
+    | TokenIds.tk_type() => _format_entity(ast, "type", channel)
+    | TokenIds.tk_struct() => _format_entity(ast, "struct", channel)
+
+    // Method types
+    | TokenIds.tk_fun() => _format_method(ast, "fun", channel)
+    | TokenIds.tk_be() => _format_method(ast, "be", channel)
+    | TokenIds.tk_new() => _format_method(ast, "new", channel)
+
+    // Field types
+    | TokenIds.tk_flet() => _format_field(ast, "let", channel)
+    | TokenIds.tk_fvar() => _format_field(ast, "var", channel)
+    | TokenIds.tk_embed() => _format_field(ast, "embed", channel)
+
+    // Local variable declarations
+    | TokenIds.tk_let() => _format_local_var(ast, "let", channel)
+    | TokenIds.tk_var() => _format_local_var(ast, "var", channel)
+
+    // Type references - try to follow to definition
+    | TokenIds.tk_reference() => _format_reference(ast, channel)
+    | TokenIds.tk_nominal() => _format_reference(ast, channel)
+
+    // Identifier - try to get info from parent or follow to definition
+    | TokenIds.tk_id() => _format_id(ast, channel)
+
+    else
+      // For other node types, return None
+      None
+    end
+
+  fun tag _format_entity(ast: AST box, keyword: String, channel: Channel): (String | None) =>
+    """
+    Format entity declarations (class, actor, trait, etc.)
+    Entity structure: child(0) = id, child(1) = cap, child(2) = cap, child(3) = provides,
+                      child(4) = members, child(5) = at, child(6) = docstring
+    """
+    match extract_entity_info(ast, keyword, channel)
+    | let info: EntityInfo => format_entity(info)
+    | None => None
+    end
+
+  fun tag extract_entity_info(ast: AST box, keyword: String, channel: Channel): (EntityInfo | None) =>
+    """
+    Extract entity information from AST node.
+    """
+    try
+      let id = ast(0)?
+      if id.id() == TokenIds.tk_id() then
+        let name = id.token_value() as String
+
+        // Try to extract type parameters
+        let type_params_str = try
+          let type_params = ast(3)?
+          if type_params.id() == TokenIds.tk_typeparams() then
+            _extract_type_params(type_params, channel)
+          else
+            ""
+          end
+        else
+          ""
+        end
+
+        // Extract docstring from child 6
+        let docstring: String = try
+          let doc_node = ast(6)?
+          if doc_node.id() == TokenIds.tk_string() then
+            doc_node.token_value() as String
+          else
+            ""
+          end
+        else
+          ""
+        end
+
+        EntityInfo(keyword, name, type_params_str, docstring)
+      else
+        None
+      end
+    else
+      None
+    end
+
+  fun tag _format_method(ast: AST box, keyword: String, channel: Channel): (String | None) =>
+    """
+    Format method declarations (fun, be, new)
+    Method structure: child(0) = cap, child(1) = id, child(2) = typeparams, child(3) = params,
+                      child(4) = return_type, child(5) = error, child(6) = body, child(7) = docstring
+    """
+    match extract_method_info(ast, keyword, channel)
+    | let info: MethodInfo => format_method(info)
+    | None => None
+    end
+
+  fun tag extract_method_info(ast: AST box, keyword: String, channel: Channel): (MethodInfo | None) =>
+    """
+    Extract method information from AST node.
+    """
+    try
+      let id = ast(1)?
+      if id.id() == TokenIds.tk_id() then
+        let name = id.token_value() as String
+
+        // Extract parameters
+        let params_str = try
+          let params = ast(3)?
+          _extract_params(params, channel)
+        else
+          "()"
+        end
+
+        // Extract return type (only for fun/be, not new)
+        let return_type_str = if (keyword == "fun") or (keyword == "be") then
+          try
+            let return_type = ast(4)?
+            ": " + _extract_type(return_type, channel)
+          else
+            ""
+          end
+        else
+          ""
+        end
+
+        // Extract docstring from child 7
+        let docstring: String = try
+          let doc_node = ast(7)?
+          if doc_node.id() == TokenIds.tk_string() then
+            doc_node.token_value() as String
+          else
+            ""
+          end
+        else
+          ""
+        end
+
+        MethodInfo(keyword, name, params_str, return_type_str, docstring)
+      else
+        None
+      end
+    else
+      None
+    end
+
+  fun tag _format_field(ast: AST box, keyword: String, channel: Channel): (String | None) =>
+    """
+    Format field declarations (let, var, embed)
+    Field structure: child(0) = id, child(1) = type, child(2) = initializer
+    Note: Fields don't support docstrings in Pony syntax
+    """
+    match _extract_field_info(ast, keyword, channel)
+    | let info: FieldInfo => format_field(info)
+    | None => None
+    end
+
+  fun tag _extract_field_info(ast: AST box, keyword: String, channel: Channel): (FieldInfo | None) =>
+    """
+    Extract field information from AST node.
+    """
+    try
+      let id = ast(0)?
+      if id.id() == TokenIds.tk_id() then
+        let name = id.token_value() as String
+
+        // Extract type annotation
+        let type_str = try
+          let field_type = ast(1)?
+          ": " + _extract_type(field_type, channel)
+        else
+          ""
+        end
+
+        FieldInfo(keyword, name, type_str)
+      else
+        None
+      end
+    else
+      None
+    end
+
+  fun tag _format_local_var(ast: AST box, keyword: String, channel: Channel): (String | None) =>
+    """
+    Format local variable declarations (let, var)
+    Local var structure: child(0) = id, child(1) = type
+    """
+    match _extract_local_var_info(ast, keyword, channel)
+    | let info: FieldInfo => format_field(info)  // Same format as fields
+    | None => None
+    end
+
+  fun tag _extract_local_var_info(ast: AST box, keyword: String, channel: Channel): (FieldInfo | None) =>
+    """
+    Extract local variable information from AST node.
+    """
+    try
+      let id = ast(0)?
+      if id.id() == TokenIds.tk_id() then
+        let name = id.token_value() as String
+
+        // Extract type annotation if present
+        let type_str = try
+          let var_type = ast(1)?
+          if var_type.id() != TokenIds.tk_none() then
+            ": " + _extract_type(var_type, channel)
+          else
+            ""
+          end
+        else
+          ""
+        end
+
+        FieldInfo(keyword, name, type_str)
+      else
+        None
+      end
+    else
+      None
+    end
+
+  fun tag _format_id(ast: AST box, channel: Channel): (String | None) =>
+    """
+    Format identifier nodes - look at parent to get full context, or follow to definition
+    """
+    try
+      let name = ast.token_value() as String
+
+      // First, try to get the parent node to determine if this is a declaration
+      match ast.parent()
+      | let parent: AST =>
+        // Check what kind of declaration this ID belongs to
+        match parent.id()
+        | TokenIds.tk_class() => _format_entity(parent, "class", channel)
+        | TokenIds.tk_actor() => _format_entity(parent, "actor", channel)
+        | TokenIds.tk_trait() => _format_entity(parent, "trait", channel)
+        | TokenIds.tk_interface() => _format_entity(parent, "interface", channel)
+        | TokenIds.tk_primitive() => _format_entity(parent, "primitive", channel)
+        | TokenIds.tk_type() => _format_entity(parent, "type", channel)
+        | TokenIds.tk_struct() => _format_entity(parent, "struct", channel)
+        | TokenIds.tk_fun() => _format_method(parent, "fun", channel)
+        | TokenIds.tk_be() => _format_method(parent, "be", channel)
+        | TokenIds.tk_new() => _format_method(parent, "new", channel)
+        | TokenIds.tk_flet() => _format_field(parent, "let", channel)
+        | TokenIds.tk_fvar() => _format_field(parent, "var", channel)
+        | TokenIds.tk_embed() => _format_field(parent, "embed", channel)
+        | TokenIds.tk_let() => _format_local_var(parent, "let", channel)
+        | TokenIds.tk_var() => _format_local_var(parent, "var", channel)
+        else
+          // Parent is not a declaration - try to follow to definition
+          _format_from_definition(ast, channel)
+        end
+      else
+        // No parent - try to follow to definition
+        _format_from_definition(ast, channel)
+      end
+    else
+      None
+    end
+
+  fun tag _format_reference(ast: AST box, channel: Channel): (String | None) =>
+    """
+    Format type reference nodes by following to their definition
+    """
+    _format_from_definition(ast, channel)
+
+  fun tag _format_from_definition(ast: AST box, channel: Channel): (String | None) =>
+    """
+    Follow an identifier or reference to its definition and format that
+    """
+    try
+      // Use definitions() to find where this is defined
+      let defs = ast.definitions()
+      if defs.size() > 0 then
+        // Get the first definition
+        let definition = defs(0)?
+        // Format the definition based on its type
+        match definition.id()
+        | TokenIds.tk_class() => _format_entity(definition, "class", channel)
+        | TokenIds.tk_actor() => _format_entity(definition, "actor", channel)
+        | TokenIds.tk_trait() => _format_entity(definition, "trait", channel)
+        | TokenIds.tk_interface() => _format_entity(definition, "interface", channel)
+        | TokenIds.tk_primitive() => _format_entity(definition, "primitive", channel)
+        | TokenIds.tk_type() => _format_entity(definition, "type", channel)
+        | TokenIds.tk_struct() => _format_entity(definition, "struct", channel)
+        | TokenIds.tk_fun() => _format_method(definition, "fun", channel)
+        | TokenIds.tk_be() => _format_method(definition, "be", channel)
+        | TokenIds.tk_new() => _format_method(definition, "new", channel)
+        | TokenIds.tk_flet() => _format_field(definition, "let", channel)
+        | TokenIds.tk_fvar() => _format_field(definition, "var", channel)
+        | TokenIds.tk_embed() => _format_field(definition, "embed", channel)
+        | TokenIds.tk_let() => _format_local_var(definition, "let", channel)
+        | TokenIds.tk_var() => _format_local_var(definition, "var", channel)
+        else
+          // Unknown definition type
+          None
+        end
+      else
+        // No definitions found
+        None
+      end
+    else
+      None
+    end
+
+  fun tag _extract_params(params: AST box, channel: Channel): String =>
+    """
+    Extract parameter list from params node.
+    Returns formatted parameter list like "(x: U32, y: String)"
+    """
+    if params.id() == TokenIds.tk_params() then
+      let param_strs = Array[String]
+      for param in params.children() do
+        try
+          // Each param has structure: child(0) = id, child(1) = type
+          let param_id = param(0)?
+          if param_id.id() == TokenIds.tk_id() then
+            let param_name = param_id.token_value() as String
+            let param_type = try
+              let ptype = param(1)?
+              ": " + _extract_type(ptype, channel)
+            else
+              ""
+            end
+            param_strs.push(param_name + param_type)
+          end
+        end
+      end
+      "(" + ", ".join(param_strs.values()) + ")"
+    else
+      "()"
+    end
+
+  fun tag _extract_type_params(type_params: AST box, channel: Channel): String =>
+    """
+    Extract type parameters from typeparams node.
+    Returns formatted type params like "[T: Trait, U: Other]"
+    """
+    let type_param_strs = Array[String]
+    for type_param in type_params.children() do
+      try
+        // Type parameter structure: child(0) = id, child(1) = constraint (optional)
+        let tp_id = type_param(0)?
+        if tp_id.id() == TokenIds.tk_id() then
+          let tp_name = tp_id.token_value() as String
+          let constraint = try
+            let constraint_node = type_param(1)?
+            ": " + _extract_type(constraint_node, channel)
+          else
+            ""
+          end
+          type_param_strs.push(tp_name + constraint)
+        end
+      end
+    end
+    if type_param_strs.size() > 0 then
+      "[" + ", ".join(type_param_strs.values()) + "]"
+    else
+      ""
+    end
+
+  fun tag _extract_type(type_node: AST box, channel: Channel): String =>
+    """
+    Extract type information from a type node.
+    This is a simplified version that tries to extract the type name.
+    """
+    let node_id = type_node.id()
+    match node_id
+    | TokenIds.tk_nominal() =>
+      // Nominal type - try to get the type name
+      // TK_NOMINAL structure: child(0) = package id ($0 for builtin), child(1) = type name
+      try
+        let num_children = type_node.num_children()
+        if num_children > 1 then
+          let type_id = type_node(1)?
+          if type_id.id() == TokenIds.tk_id() then
+            type_id.token_value() as String
+          else
+            // Try to recursively extract from child
+            _extract_type(type_id, channel)
+          end
+        else
+          "?"
+        end
+      else
+        "?"
+      end
+    | TokenIds.tk_id() =>
+      // Direct ID node
+      try
+        type_node.token_value() as String
+      else
+        "?"
+      end
+    else
+      // For other type node types, return a placeholder
+      // This could be expanded to handle more complex types
+      TokenIds.string(node_id)
+    end
+
+  fun tag _wrap_code_block(content: String): String =>
+    """
+    Wrap content in a Pony code block for markdown formatting.
+    """
+    "```pony\n" + content + "\n```"


### PR DESCRIPTION
### Context

  Language Server Protocol hover provides contextual information when users hover over code elements in their editor. This is a fundamental LSP capability that improves developer experience by showing type information, method signatures, and documentation without needing to navigate to definitions.

###  Changes

I've made a start on implementing hover capability with support for:
  - Entity declarations (class, actor, trait, interface, primitive, type, struct)
  - Method signatures with parameters and return types (fun, be, new)
  - Field declarations with type annotations (let, var, embed)
  - Local variable declarations with inferred types
  - Reference resolution to definitions
  - Docstring extraction and display
  - Markdown formatting with Pony syntax highlighting


https://github.com/user-attachments/assets/6d0216ca-3776-4547-955b-5d91a283d993

###  Limitations


There's still more work to be done, the proposed implementation does not support:
  - Hovering over function calls to show signatures
  - Hovering over variable usage (only works on declarations)
  - Complex type expressions (unions, intersections, tuples)
  - Full documentation for numeric primitives (U32, I64, etc.)
  - Receiver capabilities in method signatures (box, ref, val)