### PR TITLE
Improve installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ Language server for Pony. For more information see the [Language Server Standard
 
 ---
 
+## Installation
+
+### Homebrew (macOS and Linux)
+
+The easiest way to install `pony-lsp` on macOS and Linux is via Homebrew:
+
+```sh
+brew install pony-language-server
+```
+
+### VSCode Extension
+
+After installing the language server binary, install the VSCode extension:
+
+1. Build the extension package: `make vscode_extension`
+2. Install the generated `.vsix` file:
+   ```sh
+   code --install-extension build/release/pony-lsp-*.vsix
+   ```
+
+### Building from Source
+
+If you prefer to build from source or are on a platform without Homebrew support, see the [Creating the Language Server binary](#creating-the-language-server-binary) section below.
+
+---
+
 ## Structure
 
 The language server is started as a separate actor,
@@ -25,7 +51,27 @@ The VSCode extension resides in the folder `client_vscode`.
 
 ## Development
 
-- Build ponyc: `cd ponyc`, `make libs`, `make configure`, `make build`
+### Prerequisites
+
+- **Install ponyc**: The Pony compiler is required for development.
+
+  On macOS and Linux via Homebrew:
+  ```sh
+  brew install ponyc
+  ```
+
+  For other platforms or building from source, see [https://github.com/ponylang/ponyc](https://github.com/ponylang/ponyc)
+
+- **Install corral**: The Pony dependency manager is required for development.
+
+  On macOS and Linux via Homebrew:
+  ```sh
+  brew install corral
+  ```
+
+  For other platforms or building from source, see [https://github.com/ponylang/corral](https://github.com/ponylang/corral)
+
+### Setup Steps
 
 - Prepare VSCode extension: `cd client_vscode`, `npm i`
 


### PR DESCRIPTION
### Context

The README lacked clear installation instructions for users wanting to install pony-lsp. Users had to navigate to the development or build sections to figure out how to get started. The Development section also didn't mention required dependencies like corral.

### Changes

  - Added Installation section at the top of README with three subsections:
    - Homebrew installation for macOS/Linux (brew install pony-language-server)
    - VSCode extension installation steps
    - Building from source reference
  - Reorganized Development section with Prerequisites subsection covering:
    - ponyc installation via Homebrew or from source
    - corral installation via Homebrew or from source
  - Linked to official GitHub repositories for alternative installation methods

 ### Consequences

Users can now quickly find installation instructions without navigating through development documentation. Developers have a clearer checklist of prerequisites before starting development work.

Resolves #17 